### PR TITLE
start of configurable mesh processor support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,4 +161,5 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
+.DS_Store

--- a/ctod/core/cog/cog.py
+++ b/ctod/core/cog/cog.py
@@ -1,9 +1,11 @@
+from typing import Optional
+
 from morecantile import TileMatrixSet
 from rio_tiler.io import Reader
 from rio_tiler.models import ImageData
 
 
-def download_tile(tms: TileMatrixSet, x: int, y: int, z: int, geotiff_path: str, resampling_method="bilinear") -> ImageData:
+def download_tile(tms: TileMatrixSet, x: int, y: int, z: int, geotiff_path: str, resampling_method="bilinear", buffer: Optional[float] = 0.0) -> ImageData:
     """Retrieve an image from a Cloud Optimized GeoTIFF based on a tile index.
 
     Args:
@@ -13,13 +15,14 @@ def download_tile(tms: TileMatrixSet, x: int, y: int, z: int, geotiff_path: str,
         z (int): z tile index.
         geotiff_path (str): Path or URL to the Cloud Optimized GeoTIFF.
         resampling_method (str, optional): RasterIO resampling algorithm. Defaults to "bilinear".
+        buffer (float, optional): buffer to use in request, especially needed for martini
 
     Returns:
         ImageData: _description_
     """
 
     with Reader(geotiff_path, tms=tms) as src:     
-        image_data = src.tile(tile_z=z, tile_x=x, tile_y=y, resampling_method=resampling_method)
+        image_data = src.tile(tile_z=z, tile_x=x, tile_y=y, resampling_method=resampling_method, buffer=buffer)
         
         # Set nodata to 0 if nodata is present in the metadata
         nodata_value = src.info().nodata_value if hasattr(src.info(), 'nodata_value') else None

--- a/ctod/core/cog/cog_request.py
+++ b/ctod/core/cog/cog_request.py
@@ -5,6 +5,7 @@ from ctod.core import utils
 from ctod.core.cog.cog import download_tile
 from ctod.core.cog.processor.cog_processor import CogProcessor
 from ctod.core.utils import generate_cog_cache_key
+from ctod.core.settings import get_mesh_max_error
 from rio_tiler.errors import TileOutsideBounds
 
 class CogRequest:
@@ -23,6 +24,10 @@ class CogRequest:
         self.data = None
         self.processed_data = None
         self.timestamp = time.time()
+        # todo: mesh_processor should be defined at query not apriori
+        self.flip_y = False # todo: flip if 'martini' in str(self.cog_processor.__class__).lower()?
+        self.max_error: float = get_mesh_max_error(self.z)
+        self.buffer = 0.0 # todo: 0.5 if 'martini' in str(self.cog_processor.__class__).lower() else 0.0?
         self._future = None
     
     def set_data(self, data, processed_data, is_out_of_bounds):
@@ -40,7 +45,7 @@ class CogRequest:
 
     def _download(self):
         try:
-            dowloaded_data = download_tile(self.tms, self.x, self.y, self.z, self.cog, self.resampling_method)
+            dowloaded_data = download_tile(self.tms, self.x, self.y, self.z, self.cog, self.resampling_method, self.buffer)
             if dowloaded_data is not None:
                 self.data = dowloaded_data
                 self.processed_data = self.cog_processor.process(self)

--- a/ctod/core/cog/processor/cog_processor_quantized_mesh_delatin.py
+++ b/ctod/core/cog/processor/cog_processor_quantized_mesh_delatin.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+from pydelatin import Delatin
+from pydelatin.util import rescale_positions as delatin_rescale_positions
+from quantized_mesh_encoder.ecef import to_ecef
+from quantized_mesh_encoder.constants import WGS84
+from quantized_mesh_encoder.ellipsoid import Ellipsoid
+from ctod.core.cog.cog_request import CogRequest
+from ctod.core.cog.processor.cog_processor import CogProcessor
+from ctod.core.normals import calculate_normals
+from ctod.core.utils import rescale_positions
+
+class CogProcessorQuantizedMeshDelatin(CogProcessor):
+
+    def __init__(self):
+        self.encoder_cache = {}
+        self.ellipsoid: Ellipsoid = WGS84
+
+    def process(self, cog_request: CogRequest):
+        tile = cog_request.data.data[0]
+        tile_size: int = tile.shape[0]
+        tin = Delatin(tile, height=tile_size, width=tile_size, max_error=cog_request.max_error)
+        vertices_new = tin.vertices.astype(np.float64)
+        triangles_new = np.array(tin.triangles, dtype=np.uint32)  # in case we have more than 65536 vertices
+        normals = None
+        if cog_request.generate_normals:
+            rescaled = rescale_positions(vertices_new, cog_request.tile_bounds, flip_y=cog_request.flip_y)
+            # todo support other CRSs
+            cartesian = to_ecef(rescaled, ellipsoid=self.ellipsoid)
+            normals = calculate_normals(cartesian, triangles_new)
+        return vertices_new, triangles_new, normals

--- a/ctod/core/cog/processor/cog_processor_quantized_mesh_grid.py
+++ b/ctod/core/cog/processor/cog_processor_quantized_mesh_grid.py
@@ -25,10 +25,10 @@ class CogProcessorQuantizedMeshGrid(CogProcessor):
         vertices_new = np.array(vertices_3d, dtype=np.float64)
         triangles_new = np.array(triangles, dtype=np.uint16)
         
-        rescaled = rescale_positions(vertices_new, cog_request.tile_bounds, flip_y=False)
+        rescaled = rescale_positions(vertices_new, cog_request.tile_bounds, flip_y=cog_request.flip_y)
         cartesian = to_ecef(rescaled, ellipsoid=self.ellipsoid)
         normals = calculate_normals(cartesian, triangles_new) if cog_request.generate_normals else None
-        
+        # vetices seem to be in grid coordinate space not lat/lon
         return (vertices_new, triangles_new, normals)
                 
     def get_grid(self, num_rows, num_cols):

--- a/ctod/core/cog/processor/cog_processor_quantized_mesh_martini.py
+++ b/ctod/core/cog/processor/cog_processor_quantized_mesh_martini.py
@@ -1,0 +1,40 @@
+import numpy as np
+
+from pymartini import Martini, rescale_positions as martini_rescale_positions
+from pymartini.util import compute_backfill
+from quantized_mesh_encoder.ecef import to_ecef
+from quantized_mesh_encoder.constants import WGS84
+from quantized_mesh_encoder.ellipsoid import Ellipsoid
+from ctod.core.cog.cog_request import CogRequest
+from ctod.core.cog.processor.cog_processor import CogProcessor
+from ctod.core.normals import calculate_normals
+from ctod.core.utils import rescale_positions
+
+
+class CogProcessorQuantizedMeshMartini(CogProcessor):
+
+    def __init__(self):
+        self.ellipsoid: Ellipsoid = WGS84
+
+    def process(self, cog_request: CogRequest):
+        tile = compute_backfill(cog_request.data.data[0].astype(np.float32))
+        # todo martini tiles must be 2^n + 1 in size, eg 257x257 not 256x256
+        tile_size: int = tile.shape[0]
+        martini: Martini = Martini(tile_size)
+        tin = martini.create_tile(tile)
+        # todo we may want to cache the tile (tin) and call max_error differently
+        vertices, triangles = tin.get_mesh(max_error=cog_request.max_error)
+        # copied from pymartini rescale positions as weirdly verts is only the 2d positions at this point
+        vertices = vertices.reshape(-1, 2).astype(np.float64)
+        vertices_new = np.zeros((max(vertices.shape), 3), dtype=np.float64)
+        vertices_new[:, :2] = vertices
+        vertices_new[:, 2] = tile[vertices[:, 1].astype(np.uint16), vertices[:, 0].astype(np.uint16)]
+        # less to do with triangles
+        triangles_new = np.array(triangles.reshape(-1, 3), dtype=np.uint32)
+        normals = None
+        if cog_request.generate_normals:
+            rescaled = rescale_positions(vertices_new, cog_request.tile_bounds, flip_y=cog_request.flip_y)
+            # todo support other CRSs
+            cartesian = to_ecef(rescaled, ellipsoid=self.ellipsoid)
+            normals = calculate_normals(cartesian, triangles_new)
+        return vertices_new, triangles_new, normals

--- a/ctod/core/cog/processor/processor_util.py
+++ b/ctod/core/cog/processor/processor_util.py
@@ -1,0 +1,15 @@
+from ctod.core.cog.processor.cog_processor import CogProcessor
+from ctod.core.cog.processor.cog_processor_quantized_mesh_grid import CogProcessorQuantizedMeshGrid
+from ctod.core.cog.processor.cog_processor_quantized_mesh_delatin import CogProcessorQuantizedMeshDelatin
+from ctod.core.cog.processor.cog_processor_quantized_mesh_martini import CogProcessorQuantizedMeshMartini
+
+MESH_PROCESSORS = dict(
+    grid = CogProcessorQuantizedMeshGrid(),
+    delatin = CogProcessorQuantizedMeshDelatin(),
+    martini = CogProcessorQuantizedMeshMartini()
+)
+
+def get_cog_processor_for_method(mesh_processor: str) -> CogProcessor:
+    # todo: there really should be a more elegant way of doing this...
+    return MESH_PROCESSORS.get(mesh_processor, MESH_PROCESSORS['grid'])
+

--- a/ctod/core/terrain/generator/terrain_generator_quantized_mesh_delatin.py
+++ b/ctod/core/terrain/generator/terrain_generator_quantized_mesh_delatin.py
@@ -1,0 +1,6 @@
+from .terrain_generator_quantized_mesh_grid import TerrainGeneratorQuantizedMeshGrid
+
+
+class TerrainGeneratorQuantizedMeshDelatin(TerrainGeneratorQuantizedMeshGrid):
+    pass
+

--- a/ctod/core/terrain/generator/terrain_generator_quantized_mesh_martini.py
+++ b/ctod/core/terrain/generator/terrain_generator_quantized_mesh_martini.py
@@ -1,0 +1,35 @@
+import logging
+import numpy as np
+
+from ctod.core.cog.cog_request import CogRequest
+
+from ctod.core.terrain.generator.terrain_generator import TerrainGenerator
+from ctod.core.terrain.terrain_request import TerrainRequest
+from ctod.core.terrain.quantize import quantize
+from ctod.core.direction import Direction
+from ctod.core.utils import rescale_positions
+from ctod.core.terrain.empty_tile import generate_empty_tile
+
+from .terrain_generator_quantized_mesh_grid import TerrainGeneratorQuantizedMeshGrid
+
+
+class TerrainGeneratorQuantizedMeshMartini(TerrainGeneratorQuantizedMeshGrid):
+    def generate(self, terrain_request: TerrainRequest):
+        main_cog = terrain_request.get_main_file()
+
+        # should not happen, in case it does return empty tile
+        if main_cog.processed_data is None:
+            logging.debug("main_cog.processed_data is None")
+            quantized_empty_tile = generate_empty_tile(main_cog.tms, main_cog.z, main_cog.x, main_cog.y)
+            return quantized_empty_tile
+
+        vertices, triangles, normals = main_cog.processed_data
+
+        # todo: Martini tiles are a bit strange to work with so some more thought is needed here
+
+        # Rescale the vertices to the tile bounds and create quantized mesh
+        rescaled_vertices = rescale_positions(vertices, main_cog.tile_bounds, flip_y=False)
+        quantized = quantize(rescaled_vertices, triangles, normals)
+
+        return quantized
+

--- a/ctod/server.py
+++ b/ctod/server.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import quantized_mesh_encoder.occlusion
 
-from ctod.core.cog.processor.cog_processor_quantized_mesh_grid import CogProcessorQuantizedMeshGrid
 from ctod.core.factory.terrain_factory import TerrainFactory
 from ctod.handlers.index import IndexHandler
 from ctod.handlers.layer import LayerJsonHandler
@@ -22,12 +21,11 @@ def log_request(handler):
             handler._request_summary(),
             1000.0 * handler.request.request_time())
     
-def make_server(tile_cache_path: str = None):
+def make_server(tile_cache_path: str = None, mesh_processor: str = 'grid'):
     """Create a Tornado web server."""
     
     patch_occlusion()    
     terrain_factory = TerrainFactory()
-    cog_processor_mesh_grid = CogProcessorQuantizedMeshGrid()
 
     # Start the periodic cache check in the background
     asyncio.ensure_future(terrain_factory.start_periodic_check())
@@ -41,7 +39,6 @@ def make_server(tile_cache_path: str = None):
                 TerrainHandler,
                 dict(
                     terrain_factory=terrain_factory,
-                    cog_processor=cog_processor_mesh_grid,
                     tile_cache_path=tile_cache_path
                 ),
             ),

--- a/ctod/templates/static/controls.js
+++ b/ctod/templates/static/controls.js
@@ -5,6 +5,7 @@ var maxZoomValue = 21;
 var cogValue =
   "./ctod/files/test_cog.tif";
 var resamplingValue = "bilinear";
+var meshingValue = "grid";
 var skipCacheValue = false;
 
 document.addEventListener("DOMContentLoaded", async () => {
@@ -26,6 +27,7 @@ function setupTweakpane() {
   cogValue = getStringParameterValue("cog", cogValue);
   resamplingValue = getStringParameterValue("resamplingMethod", resamplingValue);  
   skipCacheValue = getBoolParameterValue("skipCache", skipCacheValue);
+  meshingValue = getStringParameterValue("meshingValue", meshingValue)
 
   pane = new module.Pane({
     title: "CTOD",
@@ -102,7 +104,8 @@ function createMaterialPane() {
 function createTerrainPane() {
   const PARAMS = {
     cog: cogValue,
-    resampling: resamplingValue
+    resampling: resamplingValue,
+    meshing: meshingValue
   };
 
   cog = terrainFolder.addBinding(PARAMS, "cog", {});
@@ -167,6 +170,20 @@ function createTerrainPane() {
     resamplingValue = ev.value;
     updateTerrainProvider();
   });
+
+  const meshingMethod = terrainFolder.addBinding(PARAMS, "meshing", {
+    options: {
+      grid: "grid",
+      martini: "martini",
+      delatin: "delatin"
+    },
+  });
+
+  meshingMethod.on("change", (ev) => {
+    meshingValue = ev.value;
+    updateTerrainProvider();
+  });
+
 }
 
 function createLayerPane() {
@@ -206,7 +223,7 @@ function createLayerPane() {
 }
 
 function updateTerrainProvider() {
-  setTerrainProvider(minZoomValue, maxZoomValue, cogValue, resamplingValue, skipCacheValue);
+  setTerrainProvider(minZoomValue, maxZoomValue, cogValue, resamplingValue, skipCacheValue, meshingValue);
 }
 
 function getStringParameterValue(param, defaultValue) {

--- a/ctod/templates/static/index.js
+++ b/ctod/templates/static/index.js
@@ -52,7 +52,8 @@ function initializeLayers() {
     urlParams.get("cog") ||
     "./ctod/files/test_cog.tif";
   const skipCache = urlParams.get("skipCache") || false;
-  setTerrainProvider(minZoom, maxZoom, cog, "bilinear", skipCache);
+  const meshingMethod = urlParams.get("meshingMethod") || "grid";
+  setTerrainProvider(minZoom, maxZoom, cog, "bilinear", skipCache, meshingMethod);
 
   streetsLayer.show = true;
   satelliteLayer.show = false;
@@ -110,8 +111,8 @@ function configureViewer() {
   });
 }
 
-function setTerrainProvider(minZoom, maxZoom, cog, resamplingMethod, skipCache) {
-  const terrainProviderUrl = `${window.location.origin}/tiles?minZoom=${minZoom}&maxZoom=${maxZoom}&cog=${cog}&resamplingMethod=${resamplingMethod}&skipCache=${skipCache}`;
+function setTerrainProvider(minZoom, maxZoom, cog, resamplingMethod, skipCache, meshingMethod) {
+  const terrainProviderUrl = `${window.location.origin}/tiles?minZoom=${minZoom}&maxZoom=${maxZoom}&cog=${cog}&resamplingMethod=${resamplingMethod}&skipCache=${skipCache}&meshingMethod=${meshingMethod}`;
 
   terrainProvider = new Cesium.CesiumTerrainProvider({
     url: terrainProviderUrl,


### PR DESCRIPTION
This is a mostly work in progress PR so it's not ready to merge yet. Hope to get reviews with suggested fixes.

Partially adds delatin and martini mesh processing methods from work done in https://github.com/AndrewAnnex/monticello and elsewhere by https://github.com/kylebarron/dem-tiler.

also adds bits to the cesium default viewer to allow swapping between the methods but I was seeing cached tiles from different modes as I swapped between them so maybe some other changes are needed in the front end to make changes cleaner.

Martini tiles are not working well at all currently which I think mostly has to do with the tile edge merging stuff so I've disabled parts of the TerrainGenerator for Martini currently.

Delatin seems to work okay.. but maybe having similar issues to Martini with edge merging?

other todos: 
1. make the z axis error more easily configurable via the query url
2. add vertical exaggeration (really should be in the front end only)
3. ensure I am using Martini correctly, as it is not a drop in replacement for delatin 
4. make tile size configurable (eg 512x512 etc)